### PR TITLE
fix: fix region list sorting with WOTH and Foolish selectors

### DIFF
--- a/src/features/hints/components/RegionSelect.tsx
+++ b/src/features/hints/components/RegionSelect.tsx
@@ -5,10 +5,12 @@ type RegionSelectProps = {
 };
 
 export const RegionSelect = ({ name }: RegionSelectProps) => {
+  const regionsCopy = regions.slice();
+
   return (
     <select name={name}>
       <option>-</option>
-      {regions
+      {regionsCopy
         .sort((a, b) => {
           return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
         })


### PR DESCRIPTION
WOTH and Foolish selectors caused main region list to sort and be returned in alphabetical order. This has been changed to use a copy of the array.